### PR TITLE
postgreSQLの章、翻訳完了

### DIFF
--- a/ja/optional_postgresql_installation/README.md
+++ b/ja/optional_postgresql_installation/README.md
@@ -10,49 +10,53 @@ is copyrighted by Markus Zapke-Gründemann et al.
 
 ## Windows
 
-The easiest way to install Postgres on Windows is using a program you can find here: http://www.enterprisedb.com/products-services-training/pgdownload#windows
+PostgresをWindowsにインストールする一番簡単な方法は、次のリンクから入手できるプログラムを使うことです： http://www.enterprisedb.com/products-services-training/pgdownload#windows
 
-Choose the newest version available for your operating system. Download the installer, run it and then follow the instructions available here: http://www.postgresqltutorial.com/install-postgresql/. Take note of the installation directory as you will need it in the next step (typically, it's `C:\Program Files\PostgreSQL\9.3`).
+お使いのOSで利用できる最新のバージョンを選んでください。インストーラをダウンロードし、実行し、次のリンクの指示に従ってください：http://www.postgresqltutorial.com/install-postgresql/
+インストール先のディレクトリは次のステップで必要ですので、控えておいてください。（通常は `C:\Program Files\PostgreSQL\9.3` のようになります）
 
 ## Mac OS X
 
-The easiest way is to download the free [Postgres.app](http://postgresapp.com/) and install it like any other application on your operating system.
+一番簡単な方法は、Mac OSの他のアプリケーションと同様に、無料の [Postgres.app](http://postgresapp.com/) をダウンロードし、インストールすることです。
 
-Download it, drag to the Applications directory and run by double clicking. That's it!
+ダウンロードし、「アプリケーション」ディレクトリにドラッグし、ダブルクリックで実行してください。これでおしまいです！
 
-You'll also have to add the Postgres command line tools to your `PATH` variable, what is described [here](http://postgresapp.com/documentation/cli-tools.html).
+[ここ](http://postgresapp.com/documentation/cli-tools.html)に書かれているように、`PATH` 変数にPostgresのコマンドラインツールを追加する必要があります。
 
 ## Linux
 
-Installation steps vary from distribution to distribution. Below are the commands for Ubuntu and Fedora, but if you're using a different distro [take a look at the PostgreSQL documentation](https://wiki.postgresql.org/wiki/Detailed_installation_guides#General_Linux).
+インストール手順はディストリビューションごとに異なります。以下にあるのは、UbuntuとFedora向けのコマンドです。これら以外のディストリビューションをお使いの場合は、[PostgreSQLのドキュメント
+を参照してください](https://wiki.postgresql.org/wiki/Detailed_installation_guides#General_Linux)。
 
 ### Ubuntu
 
-Run the following command:
+次のコマンドを実行してください：
 
     sudo apt-get install postgresql postgresql-contrib
 
 ### Fedora
 
-Run the following command:
+次のコマンドを実行してください：
 
     sudo yum install postgresql93-server
 
 # Create database
 
-Next up, we need to create our first database, and a user that can access that database. PostgreSQL lets you create as many databases and users as you like, so if you're running more than one site you should create a database for each one.
+次に、最初のデータベースと、それにアクセスできるユーザを作ります。PostgreSQLでは好きなだけデータベースとユーザを作成できるので、複数のサイトを稼働させる場合は、サイトごとにデータベースを作ることになるでしょう。
 
 ## Windows
 
-If you're using Windows, there's a couple more steps we need to complete. For now it's not important for you to understand the configuration we're doing here, but feel free to ask your coach if you're curious as to what's going on.
+Windowsをお使いの場合は、完了する必要のあるいくつかの追加のステップがあります。今の時点では、ここで行う設定を理解することは重要ではありませんが、何が行われているか興味がある方はお気軽にコーチに質問してください。
 
-1. Open the Command Prompt (Start menu → All Programs → Accessories → Command Prompt)
-2. Run the following by typing it in and hitting return: `setx PATH "%PATH%;C:\Program Files\PostgreSQL\9.3\bin"`. You can paste things into the Command Prompt by right clicking and selecting `Paste`. Make sure that the path is the same one you noted during installation with `\bin` added at the end. You should see the message `SUCCESS: Specified value was saved.`.
-3. Close and then reopen the Command Prompt.
+1. コマンドプロンプトを開きます（「スタートメニュー」→「アクセサリ」→「コマンドプロンプト」）
+2. 次のように入力して、Enterキーを押して実行します：`setx PATH "%PATH%;C:\Program Files\PostgreSQL\9.3\bin"`。コマンドプロンプトを右クリックして `ペースト` を選択することで、コピー&ペーストもできます。`"%PATH%;"` に続く部分が、インストール時に控えたパスに `\bin` をつけ足したものと同じか確認してくださいね。`SUCCESS: Specified value was saved.` というメッセージが現れるでしょう。
+3. コマンドプロンプトを閉じて、再度開きます。
 
 ## Create the database
 
-First, let's launch the Postgres console by running `psql`. Remember how to launch the console?
+ますは、`psql` コマンドを実行して、Postgresコンソールを起動しましょう。コンソールの起動の仕方は覚えていますか？
+>Mac OS Xでは、`ターミナル`アプリケーションを起動して行います（「アプリケーション」→「ユーティリティ」の中にあります）。Linuxでは、おそらく「アプリケーション」→「アクセサリ」→「ターミナル」となるでしょう。Windowsでは、「スタートメニュー」→「すべてのプログラム」→「アクセサリ」→「コマンドプロンプト」となります。さらに言うと、Windowsでは、インストール時に
+
 >On Mac OS X you can do this by launching the `Terminal` application (it's in Applications → Utilities). On Linux, it's probably under Applications → Accessories → Terminal. On Windows you need to go to Start menu → All Programs → Accessories → Command Prompt. Furthermore, on Windows, `psql` might require logging in using the username and password you chose during installation. If `psql` is asking you for a password and doesn't seem to work, try `psql -U <username> -W` first and enter the password later.
 
     $ psql
@@ -147,8 +151,8 @@ In order to use the newly created database in your website project, you need to 
 
 To add new posts to your blog, you also need to create a superuser by running the code:
 
-    (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name 
-    
+    (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name
+
 Remember to replace `name` with the username. You will be prompted for email and password.
 
 Now you can run the server, log into your application with the superuser account and start adding posts to your new database.

--- a/ja/optional_postgresql_installation/README.md
+++ b/ja/optional_postgresql_installation/README.md
@@ -1,12 +1,8 @@
-# PostgreSQL installation
+# PostgreSQLのインストール
 
-> Part of this chapter is based on tutorials by Geek Girls Carrots (http://django.carrots.pl/).
+> このチャプターの一部はGeek Girls Carrotsのチュートリアルをもとにしています。(http://django.carrots.pl/).
 
-> Parts of this chapter is based on the [django-marcador
-tutorial](http://django-marcador.keimlink.de/) licensed under Creative Commons
-Attribution-ShareAlike 4.0 International License. The django-marcador tutorial
-is copyrighted by Markus Zapke-Gründemann et al.
-
+> このチャプターの一部は、Creative Commons Attribution-ShareAlike 4.0 International Licenseの下で提供される[django-marcador tutorial](http://django-marcador.keimlink.de/)をもとにしています。django-marcador tutorialは、Markus Zapke-Gründemannらに著作権が帰属します。
 
 ## Windows
 
@@ -25,8 +21,7 @@ PostgresをWindowsにインストールする一番簡単な方法は、次の�
 
 ## Linux
 
-インストール手順はディストリビューションごとに異なります。以下にあるのは、UbuntuとFedora向けのコマンドです。これら以外のディストリビューションをお使いの場合は、[PostgreSQLのドキュメント
-を参照してください](https://wiki.postgresql.org/wiki/Detailed_installation_guides#General_Linux)。
+インストール手順はディストリビューションごとに異なります。以下にあるのは、UbuntuとFedora向けのコマンドです。これら以外のディストリビューションをお使いの場合は、[PostgreSQLのドキュメントを参照してください](https://wiki.postgresql.org/wiki/Detailed_installation_guides#General_Linux)。
 
 ### Ubuntu
 
@@ -40,7 +35,7 @@ PostgresをWindowsにインストールする一番簡単な方法は、次の�
 
     sudo yum install postgresql93-server
 
-# Create database
+# データベースを作成する
 
 次に、最初のデータベースと、それにアクセスできるユーザを作ります。PostgreSQLでは好きなだけデータベースとユーザを作成できるので、複数のサイトを稼働させる場合は、サイトごとにデータベースを作ることになるでしょう。
 
@@ -52,35 +47,33 @@ Windowsをお使いの場合は、完了する必要のあるいくつかの追�
 2. 次のように入力して、Enterキーを押して実行します：`setx PATH "%PATH%;C:\Program Files\PostgreSQL\9.3\bin"`。コマンドプロンプトを右クリックして `ペースト` を選択することで、コピー&ペーストもできます。`"%PATH%;"` に続く部分が、インストール時に控えたパスに `\bin` をつけ足したものと同じか確認してくださいね。`SUCCESS: Specified value was saved.` というメッセージが現れるでしょう。
 3. コマンドプロンプトを閉じて、再度開きます。
 
-## Create the database
+## データベース作成
 
-ますは、`psql` コマンドを実行して、Postgresコンソールを起動しましょう。コンソールの起動の仕方は覚えていますか？
->Mac OS Xでは、`ターミナル`アプリケーションを起動して行います（「アプリケーション」→「ユーティリティ」の中にあります）。Linuxでは、おそらく「アプリケーション」→「アクセサリ」→「ターミナル」となるでしょう。Windowsでは、「スタートメニュー」→「すべてのプログラム」→「アクセサリ」→「コマンドプロンプト」となります。さらに言うと、Windowsでは、インストール時に
-
->On Mac OS X you can do this by launching the `Terminal` application (it's in Applications → Utilities). On Linux, it's probably under Applications → Accessories → Terminal. On Windows you need to go to Start menu → All Programs → Accessories → Command Prompt. Furthermore, on Windows, `psql` might require logging in using the username and password you chose during installation. If `psql` is asking you for a password and doesn't seem to work, try `psql -U <username> -W` first and enter the password later.
+まずは、`psql` コマンドを実行して、Postgresコンソールを起動しましょう。コンソールの起動の仕方は覚えていますか？
+>Mac OS Xでは、`ターミナル`アプリケーションを起動して行います（「アプリケーション」→「ユーティリティ」の中にあります）。Linuxでは、おそらく「アプリケーション」→「アクセサリ」→「ターミナル」となるでしょう。Windowsでは、「スタートメニュー」→「すべてのプログラム」→「アクセサリ」→「コマンドプロンプト」となります。さらに言うと、Windowsでは、インストール時に設定したユーザ名とパスワードを使ってログインすることを `psql` コマンドが求めてくるかもしれません。`psql` コマンドがパスワードの入力を求めていて、入力してもうまくいかない場合は、`psql -U <username> -W` コマンドをまず実行し、パスワードを後で入力してください。
 
     $ psql
     psql (9.3.4)
     Type "help" for help.
     #
 
-Our `$` now changed into `#`, which means that we're now sending commands to PostgreSQL. Let's create a user with `CREATE USER name;` (remember to use the semicolon):
+先頭の `$` が `#` に変わりました。これから入力するコマンドはPostgreSQLに送られることを意味します。`CREATE USER name;` コマンドでユーザを作りましょう。（最後にセミコロン(;)を使うことを覚えておいてくださいね）：
 
     # CREATE USER name;
 
-Replace `name` with your own name. You shouldn't use accented letters or whitespace (e.g. `bożena maria` is invalid - you need to convert it into `bozena_maria`). If it goes well, you should get `CREATE ROLE` response from the console.
+`name` の部分はご自分のお名前に書き換えてくださいね。アクセント文字や空白文字は使うべきではありません。（例えば `bożena maria` はうまくいきません。`bozena_maria` のように書き換える必要があります。）うまくいくと、コンソールから `CREATE ROLE` という応答が返ってきます。
 
-Now it's time to create a database for your Django project:
+いよいよあなたのDjangoプロジェクトのデータベースを作るときです：
 
     # CREATE DATABASE djangogirls OWNER name;
 
-Remember to replace `name` with the name you've chosen (e.g. `bozena_maria`).  This creates an empty database that you can now use in your project. If it goes well, you should get `CREATE DATABASE` response from the console.
+`name` は先ほど設定した名前（例 `bozena_maria`）に置き換えてくださいね。このコマンドは、あなたのプロジェクトで今から使える空っぽのデータベースを作ります。うまくいくと、コンソールから `CREATE DATABASE` という応答が返ってきます。
 
-Great - that's databases all sorted!
+素晴らしい！データベース全部が並んで表示されています。
 
-# Updating settings
+# 設定の更新
 
-Find this part in your `mysite/settings.py` file:
+`mysite/settings.py` ファイルの中から、以下の部分を見つけてください：
 
 ```python
 DATABASES = {
@@ -91,7 +84,7 @@ DATABASES = {
 }
 ```
 
-And replace it with this:
+その部分を以下のように書き換えます：
 
 ```python
 DATABASES = {
@@ -106,33 +99,33 @@ DATABASES = {
 }
 ```
 
-Remember to change `name` to the user name that you created earlier in this chapter.
+`name` をこのチャプターで作ったユーザの名前に書き換えてくださいね。
 
-# Installing PostgreSQL package for Python
+# PythonのPostgreSQL用パッケージのインストール
 
-First, install Heroku Toolbelt from https://toolbelt.heroku.com/ While we will need this mostly for deploying your site later on, it also includes Git, which might come in handy already.
+まず、Heroku Toolbelt を https://toolbelt.heroku.com/ からインストールします。これは後であなたのサイトをデプロイするときに主に必要になりますが、Gitも含んでいます。Gitはもう重宝しているかもしれませんね。
 
-Next up, we need to install a package which lets Python talk to PostgreSQL - this is called `psycopg2`. The installation instructions differ slightly between Windows and Linux/OS X.
+次は、PythonがPostgreSQLとやりとりできるようにするためのパッケージをインストールします。`psycopg2` という名前のパッケージです。Windowsの場合と、LinuxまたはOS Xの場合とで、インストール手順はわずかに異なります。
 
 ## Windows
 
-For Windows, download the pre-built file from http://www.stickpeople.com/projects/python/win-psycopg/
+Windowsでは、ビルド前のファイルを http://www.stickpeople.com/projects/python/win-psycopg/ からダウンロードしてください。
 
-Make sure you get the one corresponding to your Python version (3.4 should be the last line) and to the correct architecture (32 bit in the left column or 64 bit in the right column).
+あなたの使っているPythonのバージョンに対応するものであること（Python 3.4 対応版は最後の行にあります）と、アーキテクチャに対応するものであること（32ビット版は左の列、64ビット版は右の列です）を確認してください。
 
-Rename the downloaded file and move it so that it's now available at `C:\psycopg2.exe`.
+ダウンロードしたファイルの名前を変更してから移動し、`C:\psycopg2.exe` とします。
 
-Once that's done, enter the following command in the terminal (make sure your `virtualenv` is activated):
+ここまで終わったら、コマンドラインに以下のコマンドを入力します（`virtualenv` が有効になっていることを確認して実行してください）：
 
     easy_install C:\psycopg2.exe
 
 ## Linux and OS X
 
-Run the following in your console:
+コマンドラインで以下を実行します：
 
     (myvenv) ~/djangogirls$ pip install psycopg2
 
-If that goes well, you'll see something like this
+うまくいくと、以下のような出力が表示されるでしょう：
 
     Downloading/unpacking psycopg2
     Installing collected packages: psycopg2
@@ -141,18 +134,18 @@ If that goes well, you'll see something like this
 
 ---
 
-Once that's completed, run `python -c "import psycopg2"`. If you get no errors, everything's installed successfully.
+完了したら、`python -c "import psycopg2"` というコマンドを実行します。エラーが表示されなければ、インストールは全て成功しました。
 
-# Applying migrations and creating a superuser
+# マイグレーションの適用とsuperuserの作成
 
-In order to use the newly created database in your website project, you need to apply all the migrations. In your virtual environment run the following code:
+新しく作成したデータベースをあなたのウェブサイトのプロジェクトで使うために、全てのマイグレーションを適用する必要があります。仮想環境の中で以下のコマンドを実行してください：
 
     (myvenv) ~/djangogirls$ python manage.py migrate
 
-To add new posts to your blog, you also need to create a superuser by running the code:
+ブログに記事を追加するために、以下のコマンドを実行して、superuserを作ります：
 
     (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name
 
-Remember to replace `name` with the username. You will be prompted for email and password.
+これまでのように、コマンドの `name` はこのチャプターで作ったユーザ名に置き換えてください。メールアドレスとパスワードを入力するように指示されます。
 
-Now you can run the server, log into your application with the superuser account and start adding posts to your new database.
+以上で、サーバを起動し、superuserのアカウントでアプリケーションにログインし、新しいデータベースに記事を追加することができるようになりました。

--- a/ja/optional_postgresql_installation/README.md
+++ b/ja/optional_postgresql_installation/README.md
@@ -144,7 +144,7 @@ Windowsでは、ビルド前のファイルを http://www.stickpeople.com/projec
 
 ブログに記事を追加するために、以下のコマンドを実行して、superuserを作ります：
 
-    (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name
+    (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name 
 
 これまでのように、コマンドの `name` はこのチャプターで作ったユーザ名に置き換えてください。メールアドレスとパスワードを入力するように指示されます。
 


### PR DESCRIPTION
postgreSQLの章、翻訳終えたので、PR作成しておきます。
手順検証してみて訳を修正する考えです。

＜申し送り事項＞
* 冒頭の他チュートリアルの参照情報はDjango Girls Tutorialの同様の箇所の訳を参考にした。
* superuserはDjango Girls Tutorialと訳語を合わせた ref:https://tutorial.djangogirls.org/ja/django_admin/
* 5〜8行目の改行を外して訳した（改行があると手元のエディタでマークダウンが有効か確認できなかったため）

＜未検証の箇所＞
* リンク先を参照しながら、postgreSQLが導入できるかは未検証（後日検証予定）
* 例えば、Heroku ToolbeltはHeroku CLIに変わってしまった