### PR TITLE
[review] domain章 レビューコメント

### DIFF
--- a/ja/domain/README.md
+++ b/ja/domain/README.md
@@ -31,9 +31,9 @@ Django Girlsのお気に入りは[I want my name](https://iwantmyname.com/)で�
 
 ![](images/6.png)
 
-「Add」ボタンを押してから、下の方にある「Save changes」を押してください
+「Add」ボタンを押してから、下の方にある「Save」ボタンを押して変更を保存してください
 
-> **注意** *iwantymyname.com* 以外のドメイン業者を使った場合、DNSやCNAMEの設定を検索する画面のUIが上の画像とは違います。でもやることは同じです。新しいドメインが`yourusername.pythonanywhere.com` というドメインに向くようにCNAMEを設定してください。
+> **注意** *iwantmyname.com* 以外のドメイン業者を使った場合、DNSやCNAMEの設定を検索する画面のUIが上の画像とは違います。でもやることは同じです。新しいドメインが`yourusername.pythonanywhere.com` というドメインに向くようにCNAMEを設定してください。
 
 ドメインが実際に動き始めるまで数分かかります。あせらず待ちましょう!
 

--- a/ja/domain/README.md
+++ b/ja/domain/README.md
@@ -1,8 +1,8 @@
 # ドメイン
 
-PythonAnywhereというホスティングサイトでは、無料でドメインがもらえます。でも「.pythonanywhere.com」がブログのURLのおわりについてしまうのはいやかもしれません。「www.infinite-kitten-pictures.org」とか「www.3d-printed-steam-engine-parts.com」や「www.antique-buttons.com」や「www.mutant-unicornz.net」みたいなドメインのほうがいいかもしれませんね。
+PythonAnywhereでは、無料でドメインがもらえます。でも「.pythonanywhere.com」がブログのURLのおわりについてしまうのはいやかもしれません。「www.infinite-kitten-pictures.org」とか「www.3d-printed-steam-engine-parts.com」や「www.antique-buttons.com」や「www.mutant-unicornz.net」みたいなドメインのほうがいいかもしれませんね。
 
-ここではドメインを取る方法とPythonAnywhereでホスティングしたウェブアプリにそのドメインを割り当てる方法を取り上げます。知ってるかもしれませんが、ドメインを取るにはお金がかかります。PythonAnywhereでも自分のドメイン名を使うには月額料金がかかります(そんなに高くはありません。でも本気でやりたいなら払ってもいいかもしれませんね!)。
+ここではドメインの取得先とPythonAnywhereのウェブアプリにそのドメインを割り当てる方法を取り上げます。ですが、ドメインを取るにはお金がかかり、PythonAnywhereで自分のドメイン名を使うには月額料金がかかります(そんなに高くはありません。でも本気でやりたいときにならおそらく払ってもいいと思えるでしょうね!)。
 
 
 ## どこでドメインを登録するか?
@@ -11,7 +11,7 @@ PythonAnywhereというホスティングサイトでは、無料でドメイン
 
 Django Girlsのお気に入りは[I want my name](https://iwantmyname.com/)です。「苦労しないドメイン管理」をうたっていますし、ほんとに苦労しません。
 
-無料でドメインを取ることもできます。例えば[dot.tk](http://www.dot.tk)です。でも無料のドメインだと安っぽいと感じるかもしれません。もし会社のサイトを作るつもりなら、「.com」で終わる「正式」なドメインを考えたほうがいいかもしれません。
+無料でドメインを取ることもできます。例えば[dot.tk](http://www.dot.tk)です。でも無料のドメインだと安っぽいと感じるかもしれません。もし本格的なビジネスのためのサイトを作るつもりなら、「.com」で終わる「正式」なドメインの購入を考えたほうがいいかもしれません。
 
 ## PythonAnywhereに取得したドメインを向ける
 
@@ -26,40 +26,40 @@ Django Girlsのお気に入りは[I want my name](https://iwantmyname.com/)で�
 見つかったら、下のとおりに入力してください。
 - Hostname: www
 - Type: CNAME
-- Value: PythonAnywhereでもらったドメイン (例えば、djangogirls.pythonanywhere.com)
+- Value: PythonAnywhereのドメイン (例えば、djangogirls.pythonanywhere.com)
 - TTL: 60
 
 ![](images/6.png)
 
 「Add」ボタンを押してから、下の方にある「Save changes」を押してください
 
-> **注意** **iwantymyname.com**以外のドメイン業者を使った場合、DNSやCNAMEの設定を検索をする画面のUIが上の画像とは違います。でもやることは同じです。CNAMEが `yourusername.pythonanywhere.com` というPythonAnywhareで取得したドメインに向くようにしてください。
+> **注意** *iwantymyname.com* 以外のドメイン業者を使った場合、DNSやCNAMEの設定を検索する画面のUIが上の画像とは違います。でもやることは同じです。新しいドメインが`yourusername.pythonanywhere.com` というドメインに向くようにCNAMEを設定してください。
 
 ドメインが実際に動き始めるまで数分かかります。あせらず待ちましょう!
 
-## PythonAnywhereのドメインの設定をする
+## PythonAnywhereのウェブアプリにドメインの設定をする
 
 PythonAnywhereにも取得したカスタムドメインを使うための設定が必要です。
 
 [PythonAnywhere Accounts page](https://www.pythonanywhere.com/account/)を開いて、アカウントをアップグレードしましょう。一番安い「Hacker」プランで大丈夫です。プランの変更はいつでもできます。変更するのはサイトがものすごく有名になってヒット数が数百万になったらでよいでしょう。
 
-さて、次に[Web tab](https://www.pythonanywhere.com/web_app_setup/)を開いてください。
+さて、次に[Web tab](https://www.pythonanywhere.com/web_app_setup/)を開いて、いくつか書き留めます。
 
-*  **path to your virtualenv** をどこかに書き留めて、保管しておいてください。
-*  **wsgi config file** をクリックしてください。出てきた内容を書き留めて、保管しておいてください。
+*  **virtualenvのパス** をコピーし、どこかにペーストして、保管しておいてください。
+*  **wsgi config file** をクリックしてください。出てきた内容をコピーし、どこかにペーストし、保管しておいてください。
 
-続いて、 古いウェブアプリを**Delete**を押して、削除します。削除と言っても、コードが全部消えたりしませんので安心してください。*yourusername.pythonanywhere.com* のドメインが無効になるだけです。消したら新しいウェブアプリを作りましょう。下のとおりにしてください。
+続いて、 古いウェブアプリを**Delete**を押して、削除します。削除と言っても、コードが消えることはありませんので安心してください。*yourusername.pythonanywhere.com* のドメインが無効になるだけです。消したら新しいウェブアプリを作りましょう。下のとおりにしてください。
 
-* 新しいドメイン名を入れる
+* 新しいドメイン名を入力する
 * 「manual configuration」を選ぶ
 * 「Python 3.4」を選ぶ
 * 完了!
 
 「web」タブに戻ったら・・・
 
-* さっき保存した「virtualenv path」の内容を貼り付けてください
+* さっき保存した「virtualenvのパス」を貼り付けてください
 * 「wsgi configuration file」の中に、さっき保存した「wsgi config file」の内容を貼り付けてください
 
-ブラウザに新しいドメインを入力してください。あなたのウェブアプリが動いてるのがわかるはずです。
+ウェブアプリの「Reload」をクリックしてください。新しいドメインであなたのウェブアプリが動いているのがわかるはずです。
 
-PythonAnywhereでは、うまく行かないことがあったら、「Send feedback」を押してください。管理者の誰かがすぐに助けてくれます。
+PythonAnywhereでは、うまく行かないことがあったら、「Send feedback」を押してください。親切な管理者の誰かがすぐに助けてくれます。

--- a/ja/domain/README.md
+++ b/ja/domain/README.md
@@ -15,15 +15,15 @@ Django Girlsのお気に入りは[I want my name](https://iwantmyname.com/)で�
 
 ## PythonAnywhereに取得したドメインを向ける
 
- *iwantmyname.com* をひらいたら、メニューの `Domains` をクリックして、新しく買ったドメインを選んでください。それから `manage DNS records` のリンクを探してクリックします。
+ *iwantmyname.com* をひらいたら、メニューの `Domains` をクリックして、新しく買ったドメインを選んでください。それから `manage DNS records` のリンクを探してクリックします：
 
 ![](images/4.png)
 
-それから、下の画像のフォームを探してください。
+それから、下の画像のフォームを探してください：
 
 ![](images/5.png)
 
-見つかったら、下のとおりに入力してください。
+見つかったら、下のとおりに入力してください：
 - Hostname: www
 - Type: CNAME
 - Value: PythonAnywhereのドメイン (例えば、djangogirls.pythonanywhere.com)
@@ -43,12 +43,12 @@ PythonAnywhereにも取得したカスタムドメインを使うための設定
 
 [PythonAnywhere Accounts page](https://www.pythonanywhere.com/account/)を開いて、アカウントをアップグレードしましょう。一番安い「Hacker」プランで大丈夫です。プランの変更はいつでもできます。変更するのはサイトがものすごく有名になってヒット数が数百万になったらでよいでしょう。
 
-さて、次に[Web tab](https://www.pythonanywhere.com/web_app_setup/)を開いて、いくつか書き留めます。
+さて、次に[Web tab](https://www.pythonanywhere.com/web_app_setup/)を開いて、いくつか書き留めます：
 
 *  **virtualenvのパス** をコピーし、どこかにペーストして、保管しておいてください。
 *  **wsgi config file** をクリックしてください。出てきた内容をコピーし、どこかにペーストし、保管しておいてください。
 
-続いて、 古いウェブアプリを**Delete**を押して、削除します。削除と言っても、コードが消えることはありませんので安心してください。*yourusername.pythonanywhere.com* のドメインが無効になるだけです。消したら新しいウェブアプリを作りましょう。下のとおりにしてください。
+続いて、 古いウェブアプリを**Delete**を押して、削除します。削除と言っても、コードが消えることはありませんので安心してください。*yourusername.pythonanywhere.com* のドメインが無効になるだけです。消したら新しいウェブアプリを作りましょう。下のとおりにしてください：
 
 * 新しいドメイン名を入力する
 * 「manual configuration」を選ぶ


### PR DESCRIPTION
### 概要
以下の翻訳のレビュー
https://github.com/DjangoGirlsJapan/tutorial-extensions/pull/5/files

＜方針＞
* Django Girls Tutorialの読者を想定し、冗長と感じそうな訳を省略。（言葉を補っていただいたのは大変ありがたいです。対象読者にとって明らかなPythonAnywhereの説明箇所などを削除しました）（3行目など）
* Django Girls Tutorialを通して、文末のコロンを句点にせずコロンとして訳している

＜修正箇所＞
* 5行目：「where to get a domain」「this is probably something you only want to do if you're really committed!」の訳を提案
* 14行目：「if your site is going to be for a professional business, you might want to think about paying for a "proper" domain that ends in `.com`.」の訳を提案
* 34行目：iwantmynameのヘルプページを確認したところ、「Save changes」というボタンではないようです。UIの変更に耐えられるよう"「Save」ボタンを押し"という訳を提案します。ref:https://help.iwantmyname.com/customer/portal/articles/209023-how-do-i-add-a-cname-dns-record-
* 36行目：補っていただいたiwantmyname.comのタイポ修正・マークアップ修正（18行目に合わせ、太字ではなく斜体）。「to set up a CNAME that points your new domain at `yourusername.pythonanywhere.com`.」の訳を提案
* 40行目：「Configure the domain via a web app on PythonAnywhere.」の「via a web app」の訳を提案
* 46行目：「note down a couple of things」の訳を追加。Note down 書き留める ref:https://eow.alc.co.jp/search?q=note+down
* 48, 49行目：コピーペーストすることが伝わるように訳を提案
* 48, 60行目：PythonAnywhereには「path to your virtualenv」という項目はなく、「Virtualenv」という項目でパスが確認できた
* 51行目：「this doesn't delete any of your code」の訳を提案
* 63行目：「Hit reload web app」はPythonAnywhere Webタブの「Reload」ボタンと考えます。「on its new domain」の訳を追加
* 65行目：「friendly admins」の訳を追加

＜検証中につまづいた点＞ 
これらは日本語訳に取り込んでいません。原文側に送るPRを用意します。
* 29行目：deleteするとPythonAnywhereのドメインが変わる仕様のため再設定が必要（PythonAnywhereのWebタブのDNS Setupという項目に表示される）
* 30行目：dot.tkで進めたところ、TTLを60に設定できず（3600に設定。60秒が短すぎて設定できなかったと理解）
* 54行目：画面表示は「Manual Configuration」（語の先頭が大文字）
* 55行目：Pythonのバージョンを3.6にする（Django Girls Tutorialとバージョンを合わせる）
* 未記載：mysite/settings.pyのALLOWED_HOSTSにドメインを加える必要がある
* 未記載：WebタブのStatic filesに設定をする必要がある（スタイル崩れの解決のため）ref:https://help.pythonanywhere.com/pages/DjangoStaticFiles/